### PR TITLE
ImproveResponse

### DIFF
--- a/catchresponseexception/build.gradle
+++ b/catchresponseexception/build.gradle
@@ -34,10 +34,10 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     implementation 'com.squareup.retrofit2:retrofit:2.6.1'
-    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.6.0'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.6.1'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.9.1'
 
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.7'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.8'
 }

--- a/catchresponseexception/src/main/java/danilo/desenv/catchresponseexception/response/ConstraintApi.kt
+++ b/catchresponseexception/src/main/java/danilo/desenv/catchresponseexception/response/ConstraintApi.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class ConstraintApi(
     @SerializedName("name")
-    val name: String,
+    val name: String?,
     @SerializedName("params")
     val params: List<ParamApi>
 )

--- a/catchresponseexception/src/main/java/danilo/desenv/catchresponseexception/response/ErrorApi.kt
+++ b/catchresponseexception/src/main/java/danilo/desenv/catchresponseexception/response/ErrorApi.kt
@@ -4,11 +4,11 @@ import com.google.gson.annotations.SerializedName
 
 data class ErrorApi(
     @SerializedName("property")
-    val property: String,
+    val property: String?,
     @SerializedName("value")
-    val value: String,
+    val value: String?,
     @SerializedName("message")
-    val message: String,
+    val message: String?,
     @SerializedName("constraint")
     val constraint: ConstraintApi
 )

--- a/catchresponseexception/src/main/java/danilo/desenv/catchresponseexception/response/ParamApi.kt
+++ b/catchresponseexception/src/main/java/danilo/desenv/catchresponseexception/response/ParamApi.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class ParamApi(
     @SerializedName("name")
-    val name: String,
+    val name: String?,
     @SerializedName("value")
-    val value: String
+    val value: String?
 )


### PR DESCRIPTION
Altered responses to acpet null type return from api, Maybe the api can return a null type, so in this way the app have to do not break 